### PR TITLE
Rework shared memory with capability-scoped views

### DIFF
--- a/src/agents/file_analysis_agent.py
+++ b/src/agents/file_analysis_agent.py
@@ -197,20 +197,19 @@ Prioritize high-impact issues that affect security, performance, or maintainabil
                 # Convert to CodeIssue objects
                 issues = self._convert_to_code_issues(structured_response.issues, full_path)
 
-                # Persist findings to shared memory through the scoped view
+                # Persist findings to shared memory through the scoped view.
+                # Notes are about *this* file, so we scope them. Todos are
+                # cross-file checks - leave them unscoped so the agent that
+                # later analyzes the referenced file can see them.
                 if memory_view is not None:
                     new_todos = getattr(structured_response, 'memory_items', None) or []
                     new_notes = getattr(structured_response, 'notes', None) or []
                     if new_todos:
-                        memory_view.add_todos(new_todos, target_file=file_path)
+                        memory_view.add_todos(new_todos)
                         logger.info(f"{file_path}: added {len(new_todos)} todos")
                     if new_notes:
                         memory_view.add_notes(new_notes, file_path=file_path)
                         logger.info(f"{file_path}: added {len(new_notes)} notes")
-                    memory_view.cache_file_analysis(file_path, {
-                        'issues_count': len(issues),
-                        'focus': analysis_focus,
-                    })
 
             except Exception as e:
                 logger.warning(f"Structured analysis failed, falling back to text parsing: {e}")
@@ -225,6 +224,15 @@ Prioritize high-impact issues that affect security, performance, or maintainabil
                     }
                 )
                 issues = self._parse_text_response(response, full_path)
+
+            # Always record that we analyzed this file, regardless of which
+            # path produced the issues. Otherwise the orchestrator's "Already
+            # Analyzed Files" view drifts out of sync.
+            if memory_view is not None:
+                memory_view.cache_file_analysis(file_path, {
+                    'issues_count': len(issues),
+                    'focus': analysis_focus,
+                })
             
             logger.info(f"File analysis complete: {len(issues)} issues found in {file_path}")
             return issues

--- a/src/agents/file_analysis_agent.py
+++ b/src/agents/file_analysis_agent.py
@@ -16,7 +16,7 @@ from .schemas import (
     IssueSeverity
 )
 from ..core.config import AgentConfig
-from ..core.shared_memory import SharedMemory
+from ..core.shared_memory import SharedMemory, MemoryView, ROLE_FILE_ANALYSIS
 from ..core.repository_tree import RepositoryTreeConstructor as TreeConstructor
 from ..indexer import RulesIndexer
 from ..utils.symbol_extractor import extract_symbols
@@ -31,7 +31,9 @@ class FileAnalysisAgent(BaseAgent):
         super().__init__(config)
         self.max_file_size = 1024 * 1024  # 1MB max file size
         self.max_lines = 1000  # Max lines to analyze per file
-        self.shared_memory = shared_memory  # Shared memory for cross-codebase context
+        # Underlying memory store. Per-call, we derive a file-scoped MemoryView
+        # so each analysis can only write cache entries for the file it owns.
+        self.shared_memory = shared_memory
         
     @property
     def system_prompt(self) -> str:
@@ -53,16 +55,23 @@ Valid Categories (use ONLY these):
 - style: Code formatting issues
 - maintainability: Design issues, coupling, architectural concerns
 
-SHARED MEMORY - Cross-codebase Context:
-When analyzing files, if you discover functions/classes/logic that needs verification elsewhere:
-- Add clear, specific action items to shared memory (append-only)
-- Examples of good action items:
-  * "Check if authenticate() function has tests in test_auth.py"
-  * "Verify error handling for process_payment() is consistent across codebase"
-  * "Ensure API_KEY configuration is validated before use in api_client.py"
-  * "Check if User class methods are properly documented"
+SHARED MEMORY - how to use it:
+You see two kinds of shared memory in the prompt:
+- Notes: durable observations about the codebase (entry points, invariants,
+  where a symbol lives). Append a note in `notes` when you learn something
+  worth telling other agents.
+- Todos: action items other agents should verify. Append to `memory_items`
+  when you discover something that must be checked elsewhere (e.g.
+  "Check if authenticate() has tests in test_auth.py").
 
-Make action items specific with function/class names and relevant file paths when possible.
+Rules for file-analysis agents:
+- You can READ all notes and todos.
+- You can APPEND notes and todos via the response fields.
+- You can only modify todos you authored or that target the file you are
+  analyzing - surfaced transparently by the prompt when applicable.
+- You cannot delete notes, clear memory, or touch other files' cache.
+
+Make items specific: include function/class names and file paths.
 
 Prioritize high-impact issues that affect security, performance, or maintainability."""
         
@@ -137,14 +146,12 @@ Prioritize high-impact issues that affect security, performance, or maintainabil
             List of CodeIssue objects found in the file
         """
         logger.info(f"Analyzing file: {file_path} (focus: {analysis_focus})")
-        
-        # Get shared memory from repository context if available
-        shared_memory = None
-        if repository_context and 'shared_memory' in repository_context:
-            shared_memory = repository_context['shared_memory']
-        elif self.shared_memory:
-            shared_memory = self.shared_memory
-        
+
+        # Build a file-scoped MemoryView. The view enforces that this agent can
+        # only write the cache for this file and only modify todos it owns or
+        # that are targeted at this file.
+        memory_view = self._resolve_memory_view(repository_context, file_path)
+
         full_path = root_path / file_path
         
         if not full_path.exists():
@@ -171,9 +178,9 @@ Prioritize high-impact issues that affect security, performance, or maintainabil
                 content=content,
                 analysis_focus=analysis_focus,
                 repository_context=repository_context,
-                shared_memory=shared_memory
+                memory_view=memory_view,
             )
-            
+
             # Generate structured analysis
             try:
                 structured_response = await self.generate_structured_response(
@@ -186,15 +193,25 @@ Prioritize high-impact issues that affect security, performance, or maintainabil
                         'analysis_type': 'individual_file'
                     }
                 )
-                
+
                 # Convert to CodeIssue objects
                 issues = self._convert_to_code_issues(structured_response.issues, full_path)
-                
-                # Add generated memory items to shared memory
-                if shared_memory and hasattr(structured_response, 'memory_items') and structured_response.memory_items:
-                    shared_memory.add_items(structured_response.memory_items)
-                    logger.info(f"Added {len(structured_response.memory_items)} memory items to shared memory from {file_path}")
-                
+
+                # Persist findings to shared memory through the scoped view
+                if memory_view is not None:
+                    new_todos = getattr(structured_response, 'memory_items', None) or []
+                    new_notes = getattr(structured_response, 'notes', None) or []
+                    if new_todos:
+                        memory_view.add_todos(new_todos, target_file=file_path)
+                        logger.info(f"{file_path}: added {len(new_todos)} todos")
+                    if new_notes:
+                        memory_view.add_notes(new_notes, file_path=file_path)
+                        logger.info(f"{file_path}: added {len(new_notes)} notes")
+                    memory_view.cache_file_analysis(file_path, {
+                        'issues_count': len(issues),
+                        'focus': analysis_focus,
+                    })
+
             except Exception as e:
                 logger.warning(f"Structured analysis failed, falling back to text parsing: {e}")
                 # Fallback to text-based analysis
@@ -216,10 +233,27 @@ Prioritize high-impact issues that affect security, performance, or maintainabil
             logger.error(f"Error analyzing file {file_path}: {e}")
             return []
     
+    def _resolve_memory_view(self, repository_context: Optional[Dict[str, Any]],
+                             file_path: str) -> Optional[MemoryView]:
+        """Return a MemoryView scoped to the given file.
+
+        Accepts either a pre-built MemoryView (preferred) or a raw SharedMemory
+        in ``repository_context['shared_memory']`` for backwards compatibility.
+        """
+        if repository_context and 'shared_memory' in repository_context:
+            obj = repository_context['shared_memory']
+            if isinstance(obj, MemoryView):
+                return obj
+            if isinstance(obj, SharedMemory):
+                return obj.view_for(role=ROLE_FILE_ANALYSIS, file_scope=file_path)
+        if isinstance(self.shared_memory, SharedMemory):
+            return self.shared_memory.view_for(role=ROLE_FILE_ANALYSIS, file_scope=file_path)
+        return None
+
     def _build_file_analysis_prompt(self, file_path: str, content: str,
                                    analysis_focus: str,
                                    repository_context: Optional[Dict[str, Any]],
-                                   shared_memory: Optional[SharedMemory] = None) -> str:
+                                   memory_view: Optional[MemoryView] = None) -> str:
         """Build analysis prompt for a specific file"""
         file_extension = Path(file_path).suffix.lower()
         language = self._get_language(file_extension)
@@ -287,16 +321,19 @@ Follow these rules carefully during analysis:
             except Exception as e:
                 logger.error(f"Error querying rules RAG: {e}")
         
-        # Add shared memory context if available
-        if shared_memory and len(shared_memory) > 0:
-            memory_items = shared_memory.format_items()
-            prompt += f"""
+        # Add shared memory context (notes + todos) if available
+        if memory_view is not None:
+            memory_block = memory_view.format_for_prompt(file_path=file_path)
+            if memory_block:
+                prompt += f"""
 
-SHARED MEMORY - Existing Context:
-{memory_items}
+SHARED MEMORY:
+{memory_block}
 
-Review these items for context about what needs to be checked across the codebase."""
-        
+Use notes as grounded context. If a todo targets this file, address it and
+include a concise note in your `notes` response so other agents see the
+resolution."""
+
         prompt += f"""
 
 FILE CONTENT:
@@ -304,11 +341,14 @@ FILE CONTENT:
 
 Provide detailed issues with exact line numbers, clear descriptions, and actionable suggestions.
 
-IMPORTANT: Generate memory_items for cross-codebase verification needs:
-- Include specific function/class names and suggested files to check
-- Examples: "Check if authenticate() has tests in test_auth.py", "Verify User class usage in user_service.py"
+RESPONSE FIELDS:
+- `issues`: the code quality issues you found in this file.
+- `notes`: durable observations about this file to share with other agents
+  (e.g. "authenticate() at line 45 is the single login entry point").
+- `memory_items`: todos (cross-file checks) for other agents to pick up
+  (e.g. "Check if authenticate() has tests in test_auth.py").
 """
-        
+
         return prompt
 
     def _build_file_query_prompt(self, *, file_path: str, content: str, question: str,

--- a/src/agents/orchestrator_agent.py
+++ b/src/agents/orchestrator_agent.py
@@ -18,7 +18,7 @@ from .schemas import (
 from ..core.config import AgentConfig, RedisConfig
 from .tools import AnalyzeFile, QueryCodebase, QueryFile
 from ..core.message_history import MessageRole
-from ..core.shared_memory import SharedMemory
+from ..core.shared_memory import SharedMemory, MemoryView, ROLE_ORCHESTRATOR
 from ..core.repository_tree import RepositoryTreeConstructor as TreeConstructor
 
 logger = logging.getLogger(__name__)
@@ -49,7 +49,13 @@ class OrchestratorAgent(BaseAgent):
         self.chat_answer = None  # Store final answer for chat mode
         self._cached_analysis_result = None  # Store cached analysis for chat mode
         self.session_id = session_id  # Store message key for chat mode
-        self.shared_memory = shared_memory  # Shared memory for cross-codebase context
+        self.shared_memory = shared_memory
+        # Orchestrator has the privileged role: can prune notes, remove todos,
+        # reset memory between sessions. All other agents run through a more
+        # restricted view.
+        self.memory: Optional[MemoryView] = (
+            shared_memory.view_for(role=ROLE_ORCHESTRATOR) if shared_memory else None
+        )
         
         # Event callback for streaming updates
         self._event_callback = None
@@ -80,19 +86,21 @@ WORKFLOW:
 2. Wait for tool results
 3. Return {"issues": [...]} with findings
 
-SHARED MEMORY:
-- Review shared memory for pending action items before selecting files
-- Prioritize analyzing files related to pending action items
-- After analyzing files that address action items, you can remove completed items
-- Add new items when discovering cross-file dependencies or concerns
-- Generate memory_items in your response for cross-codebase context
+SHARED MEMORY (two layers):
+- Notes: durable codebase observations accumulated by all agents. Use them
+  as grounded context - don't re-derive what's already there.
+- Todos: pending action items with a status (pending/in_progress/done).
+  Before picking a file, scan pending todos; if any target a file, analyze
+  that file next so the todo can be resolved.
 
-Examples of good memory items:
-  * "Check if authenticate() function has tests in test_auth.py"
-  * "Verify error handling in payment_processor.py matches validation.py"
-  * "Ensure User class methods are documented"
+As the orchestrator you have full control over memory:
+- You can add notes and todos.
+- You can remove stale notes and completed todos.
+- Use `memory_items` in your response for new todos, `notes` for new
+  observations.
 
 File Priority:
+- Files referenced by pending todos
 - Entry points (main.py, index.js, app.py)
 - Core logic and configuration files
 - Large/complex files
@@ -118,11 +126,11 @@ When a user asks about the codebase:
 4. Provide comprehensive answers with code details
 
 SHARED MEMORY:
-- Review shared memory for context from previous analysis steps
-- Add action items when discovering related concerns across files
-- Generate memory_items in your response for cross-codebase context
-
-Examples: "Check if process_order() has proper error handling", "Verify API authentication is consistent"
+- Notes give you durable context discovered in past steps - consult them
+  before re-reading files.
+- Pending todos point to known gaps; address any that are relevant before
+  answering.
+- Add new observations via `notes` and cross-file checks via `memory_items`.
 """
         
         # Add query_codebase to prompt if available
@@ -233,17 +241,18 @@ FILES:
 {TreeConstructor.format_file_list(all_files)}"""
 
         # Add shared memory content if available
-        if self.shared_memory and len(self.shared_memory) > 0:
-            memory_items = self.shared_memory.format_items()
-            prompt += f"""
+        if self.memory is not None:
+            memory_block = self.memory.format_for_prompt()
+            if memory_block:
+                prompt += f"""
 
-SHARED MEMORY - Pending Action Items:
-{memory_items}
+SHARED MEMORY:
+{memory_block}
 
-Priority: Address these action items first by analyzing relevant files."""
-        
+Priority: if a pending todo targets a file, analyze that file first."""
+
         prompt += "\n\nUse analyze_file to examine critical files (entry points, configs, core logic).\nAfter analysis, return: {\"issues\": [Issues from the analysis with proper schema]}"
-        
+
         return prompt
     
     
@@ -340,12 +349,13 @@ FILES:
             prompt += f"\n\nPrevious analysis: {issues_count} issues found"
 
         # Add shared memory content if available
-        if self.shared_memory and len(self.shared_memory) > 0:
-            memory_items = self.shared_memory.format_items()
-            prompt += f"""
+        if self.memory is not None:
+            memory_block = self.memory.format_for_prompt()
+            if memory_block:
+                prompt += f"""
 
-SHARED MEMORY - Context from Previous Analysis:
-{memory_items}"""
+SHARED MEMORY:
+{memory_block}"""
 
         prompt += "\n\nYou can query relevant files if needed using the tools. Focus on files related to the user's question ONLY. DO NOT ASSUME ANYTHING."""
         

--- a/src/agents/schemas.py
+++ b/src/agents/schemas.py
@@ -70,14 +70,36 @@ class CodeIssueSchema(BaseModel):
 class AnalysisResponseSchema(BaseModel):
     """Schema for the complete analysis response"""
     issues: List[CodeIssueSchema] = Field(description="List of code quality issues found")
-    memory_items: Optional[List[str]] = Field(default_factory=list, description="Action items to add to shared memory for cross-codebase verification (e.g., 'Check if authenticate() has tests in test_auth.py')")
+    memory_items: Optional[List[str]] = Field(
+        default_factory=list,
+        description=(
+            "Todos: action items for cross-codebase verification (e.g., 'Check if "
+            "authenticate() has tests in test_auth.py'). Each item becomes a pending "
+            "todo other agents can claim."
+        ),
+    )
+    notes: Optional[List[str]] = Field(
+        default_factory=list,
+        description=(
+            "Durable observations about this file or the codebase (e.g., 'authenticate() "
+            "in src/auth.py:45 is the single entry point for login'). Stored as notes "
+            "visible to all agents."
+        ),
+    )
 
 class ChatResponseSchema(BaseModel):
     """Schema for chat mode responses"""
     answer: str = Field(description="The answer to the user's question about the codebase")
     files_to_analyze: Optional[List[str]] = Field(None, description="Files that need to be analyzed to answer the question")
     analysis_complete: bool = Field(False, description="Whether the analysis is complete and ready to provide final answer")
-    memory_items: Optional[List[str]] = Field(default_factory=list, description="Action items to add to shared memory for cross-codebase context")
+    memory_items: Optional[List[str]] = Field(
+        default_factory=list,
+        description="Action items to add to shared memory as todos for cross-codebase context",
+    )
+    notes: Optional[List[str]] = Field(
+        default_factory=list,
+        description="Durable observations about the codebase to share with other agents",
+    )
 
 
 class FileAnalysisRequestSchema(BaseModel):
@@ -97,7 +119,8 @@ class FileAnalysisResultEnhanced(BaseModel):
     """Enhanced file analysis response that includes next steps"""
     file_path: str = Field(description="Path to the analyzed file")
     issues: List[CodeIssueSchema] = Field(default_factory=list, description="Issues found in the file")
-    memory_items: Optional[List[str]] = Field(default_factory=list, description="Action items to add to shared memory for cross-codebase verification")
+    memory_items: Optional[List[str]] = Field(default_factory=list, description="Todos: action items for cross-codebase verification")
+    notes: Optional[List[str]] = Field(default_factory=list, description="Durable observations about the file for other agents")
     summary: Optional[str] = Field(None, description="Brief summary of the file analysis")
 
 

--- a/src/core/orchestrator_engine.py
+++ b/src/core/orchestrator_engine.py
@@ -10,7 +10,7 @@ import uuid
 from ..agents.schemas import AnalysisResult, CodeIssue
 from ..core.repository_tree import RepositoryTreeConstructor
 from .config import Config
-from .shared_memory import SharedMemory
+from .shared_memory import SharedMemory, ROLE_FILE_ANALYSIS
 from ..agents.orchestrator_agent import OrchestratorAgent
 from ..agents.file_analysis_agent import FileAnalysisAgent
 from ..reports.report_generator import ReportGenerator
@@ -155,7 +155,9 @@ class OrchestratorEngine:
                 'main_languages': list(tree_data['statistics']['file_extensions'].keys())[:5],
                 'tree': tree_data['tree'],
                 'project_type': self._detect_project_type(tree_data),
-                'shared_memory': self.shared_memory
+                'shared_memory': self.shared_memory.view_for(
+                    role=ROLE_FILE_ANALYSIS, file_scope=file_path
+                )
             }
             
             # Add user question context for chat mode
@@ -256,7 +258,9 @@ class OrchestratorEngine:
                     'main_languages': list(tree_data['statistics']['file_extensions'].keys())[:5],
                     'tree': tree_data['tree'],
                     'project_type': self._detect_project_type(tree_data),
-                    'shared_memory': self.shared_memory
+                    'shared_memory': self.shared_memory.view_for(
+                    role=ROLE_FILE_ANALYSIS, file_scope=file_path
+                )
                 }
                 answer = await self.file_analysis_agent.answer_file_query(
                     file_path=file_path,
@@ -315,7 +319,9 @@ class OrchestratorEngine:
                     'tree': tree_data['tree'],
                     'project_type': self._detect_project_type(tree_data),
                     'search_results': len(results.get('merged', [])),
-                    'shared_memory': self.shared_memory
+                    # Codebase-wide query: no file scope. Passed only for
+                    # downstream context; the handler does not mutate memory.
+                    'shared_memory': self.shared_memory,
                 }
                 
                 # Format the answer from search results

--- a/src/core/orchestrator_engine.py
+++ b/src/core/orchestrator_engine.py
@@ -542,6 +542,10 @@ class OrchestratorEngine:
         # Also set the callback on the orchestrator agent if it exists
         if self.orchestrator_agent:
             self.orchestrator_agent.set_event_callback(callback)
+        # Wire memory mutations through the same event stream so the UI can
+        # render note/todo changes as they happen.
+        if self.shared_memory is not None:
+            self.shared_memory.set_event_callback(callback)
     
     def _emit_event(self, event_type: str, data: dict):
         """Emit an event to the callback if one is set"""

--- a/src/core/shared_memory.py
+++ b/src/core/shared_memory.py
@@ -26,9 +26,11 @@ import uuid
 from dataclasses import dataclass, field
 from datetime import datetime
 from threading import RLock
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Callable, Dict, List, Literal, Optional
 
 logger = logging.getLogger(__name__)
+
+EventCallback = Callable[[str, Dict[str, Any]], None]
 
 TodoStatus = Literal["pending", "in_progress", "done"]
 
@@ -77,7 +79,26 @@ class SharedMemory:
         self._todos: Dict[str, Todo] = {}
         self._file_cache: Dict[str, Dict[str, Any]] = {}
         self._lock = RLock()
+        self._event_callback: Optional[EventCallback] = None
         logger.info("SharedMemory initialized")
+
+    # --- Event wiring --------------------------------------------------
+
+    def set_event_callback(self, callback: Optional[EventCallback]) -> None:
+        """Register a callback to receive memory_update events.
+
+        Signature: callback(event_type: str, data: dict).
+        """
+        self._event_callback = callback
+
+    def _emit(self, action: str, **data: Any) -> None:
+        cb = self._event_callback
+        if cb is None:
+            return
+        try:
+            cb("memory_update", {"action": action, **data})
+        except Exception as e:
+            logger.warning(f"memory event callback failed: {e}")
 
     # --- Internal state mutation (invoked through MemoryView) -----------
 
@@ -88,15 +109,25 @@ class SharedMemory:
                     return False
             self._notes.append(note)
             logger.debug(f"note+ [{note.source}] {note.content}")
-            return True
+        self._emit(
+            "note_added",
+            role=note.source,
+            content=note.content,
+            file_path=note.file_path,
+            tags=list(note.tags),
+        )
+        return True
 
     def _remove_note(self, content: str) -> bool:
         with self._lock:
             for i, n in enumerate(self._notes):
                 if n.content == content:
-                    del self._notes[i]
-                    return True
-            return False
+                    removed = self._notes.pop(i)
+                    break
+            else:
+                return False
+        self._emit("note_removed", role=removed.source, content=removed.content)
+        return True
 
     def _get_notes(self, *, tags: Optional[List[str]] = None,
                    file_path: Optional[str] = None) -> List[Note]:
@@ -115,7 +146,14 @@ class SharedMemory:
                     return existing.id
             self._todos[todo.id] = todo
             logger.debug(f"todo+ [{todo.source}] {todo.content}")
-            return todo.id
+        self._emit(
+            "todo_added",
+            role=todo.source,
+            id=todo.id,
+            content=todo.content,
+            target_file=todo.target_file,
+        )
+        return todo.id
 
     def _update_todo(self, todo_id: str, *, status: Optional[TodoStatus] = None,
                      owner: Optional[str] = None) -> bool:
@@ -123,16 +161,42 @@ class SharedMemory:
             todo = self._todos.get(todo_id)
             if not todo:
                 return False
+            prev_status = todo.status
             if status is not None:
                 todo.status = status
             if owner is not None:
                 todo.owner = owner
             todo.updated_at = datetime.now().isoformat()
-            return True
+            snapshot = (todo.id, todo.content, todo.target_file, todo.status, todo.owner)
+        _id, _content, _target, _status, _owner = snapshot
+        if status is not None and status != prev_status:
+            action = {
+                "in_progress": "todo_claimed",
+                "done": "todo_completed",
+                "pending": "todo_reopened",
+            }.get(_status, "todo_updated")
+            self._emit(
+                action,
+                role=_owner or "",
+                id=_id,
+                content=_content,
+                target_file=_target,
+                status=_status,
+            )
+        return True
 
     def _remove_todo(self, todo_id: str) -> bool:
         with self._lock:
-            return self._todos.pop(todo_id, None) is not None
+            removed = self._todos.pop(todo_id, None)
+        if removed is None:
+            return False
+        self._emit(
+            "todo_removed",
+            role=removed.source,
+            id=removed.id,
+            content=removed.content,
+        )
+        return True
 
     def _get_todos(self, *, status: Optional[TodoStatus] = None,
                    target_file: Optional[str] = None) -> List[Todo]:
@@ -161,10 +225,19 @@ class SharedMemory:
     def clear(self) -> None:
         """Reset memory for a new analysis session."""
         with self._lock:
+            note_count = len(self._notes)
+            todo_count = len(self._todos)
+            file_count = len(self._file_cache)
             self._notes.clear()
             self._todos.clear()
             self._file_cache.clear()
             logger.info("SharedMemory cleared for new session")
+        self._emit(
+            "reset",
+            notes_cleared=note_count,
+            todos_cleared=todo_count,
+            files_cleared=file_count,
+        )
 
     def snapshot(self) -> Dict[str, Any]:
         with self._lock:

--- a/src/core/shared_memory.py
+++ b/src/core/shared_memory.py
@@ -1,109 +1,367 @@
-"""Shared memory for maintaining cross-codebase context during analysis sessions"""
+"""Shared memory for multi-agent code analysis sessions.
+
+Inspired by how Claude Code handles memory. The model has three layers:
+
+- Notes: short, durable observations about the codebase (like CLAUDE.md
+  entries). Agents append; the orchestrator can prune.
+- Todos: action items with an explicit status lifecycle
+  (pending -> in_progress -> done), similar to TodoWrite. Agents add todos,
+  claim them, and mark them done. The orchestrator manages the overall list.
+- File cache: per-file analysis results. Prevents re-analyzing the same file
+  and lets agents look up what another agent already found.
+
+Each agent works through a ``MemoryView`` - a capability-scoped facade that
+controls what it can read and modify. The underlying ``SharedMemory`` store
+is the single source of truth; agents never mutate it directly.
+
+Roles:
+- "orchestrator": full read/write; manages todo lifecycle, prunes, resets.
+- "file_analysis": read-all, append notes/todos, update only its own todos
+  (or todos targeting its scoped file), cache analysis only for its scoped
+  file.
+"""
 
 import logging
-from typing import List
-from threading import Lock
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime
+from threading import RLock
+from typing import Any, Dict, List, Literal, Optional
 
 logger = logging.getLogger(__name__)
 
+TodoStatus = Literal["pending", "in_progress", "done"]
+
+ROLE_ORCHESTRATOR = "orchestrator"
+ROLE_FILE_ANALYSIS = "file_analysis"
+
+
+@dataclass
+class Note:
+    """A durable observation about the codebase."""
+    content: str
+    source: str
+    tags: List[str] = field(default_factory=list)
+    file_path: Optional[str] = None
+    created_at: str = field(default_factory=lambda: datetime.now().isoformat())
+
+    def format(self) -> str:
+        loc = f" [{self.file_path}]" if self.file_path else ""
+        tag_str = f" ({', '.join(self.tags)})" if self.tags else ""
+        return f"{self.content}{loc}{tag_str}"
+
+
+@dataclass
+class Todo:
+    """Actionable item an agent should complete."""
+    id: str
+    content: str
+    source: str
+    status: TodoStatus = "pending"
+    owner: Optional[str] = None
+    target_file: Optional[str] = None
+    created_at: str = field(default_factory=lambda: datetime.now().isoformat())
+    updated_at: str = field(default_factory=lambda: datetime.now().isoformat())
+
+    def format(self) -> str:
+        icon = {"pending": "[ ]", "in_progress": "[~]", "done": "[x]"}[self.status]
+        target = f" -> {self.target_file}" if self.target_file else ""
+        return f"{icon} {self.content}{target}"
+
 
 class SharedMemory:
-    """
-    In-memory shared memory for maintaining action items across agent interactions.
-    
-    Orchestrator can:
-    - Add items
-    - Remove items
-    - Clear all items
-    
-    Sub-agents can:
-    - Read all items
-    - Append new items (add only)
-    """
-    
-    def __init__(self):
-        """Initialize shared memory with an empty list of action items"""
-        self._items: List[str] = []
-        self._lock = Lock()
-        logger.info("SharedMemory initialized")
-    
-    def add_items(self, items: List[str]) -> None:
-        """
-        Add new action items to shared memory.
-        
-        Args:
-            items: List of action item strings to add
-        """
-        if not items:
-            return
-        
-        with self._lock:
-            # Only add unique items to avoid duplicates
-            for item in items:
-                if item and item.strip() and item not in self._items:
-                    self._items.append(item.strip())
-                    logger.debug(f"Added to shared memory: {item.strip()}")
-    
-    def remove_items(self, items: List[str]) -> None:
-        """
-        Remove specific action items from shared memory.
-        Typically used by orchestrator after items are completed.
-        
-        Args:
-            items: List of action item strings to remove
-        """
-        if not items:
-            return
-        
-        with self._lock:
-            for item in items:
-                if item in self._items:
-                    self._items.remove(item)
-                    logger.debug(f"Removed from shared memory: {item}")
-    
-    def get_all_items(self) -> List[str]:
-        """
-        Get all current action items in shared memory.
-        
-        Returns:
-            List of action item strings
-        """
-        with self._lock:
-            return self._items.copy()
-    
-    def clear(self) -> None:
-        """Clear all action items from shared memory"""
-        with self._lock:
-            count = len(self._items)
-            self._items.clear()
-            logger.info(f"Cleared {count} items from shared memory")
-    
-    def __len__(self) -> int:
-        """Return the number of items in shared memory"""
-        with self._lock:
-            return len(self._items)
-    
-    def __str__(self) -> str:
-        """String representation of shared memory"""
-        with self._lock:
-            if not self._items:
-                return "SharedMemory: empty"
-            return f"SharedMemory: {len(self._items)} items"
-    
-    def format_items(self) -> str:
-        """
-        Format all items as a numbered list for display in prompts.
-        
-        Returns:
-            Formatted string with numbered items, or empty string if no items
-        """
-        with self._lock:
-            if not self._items:
-                return ""
-            
-            formatted = []
-            for idx, item in enumerate(self._items, 1):
-                formatted.append(f"{idx}. {item}")
-            
-            return "\n".join(formatted)
+    """Authoritative memory store. Agents should access it via ``view_for``."""
 
+    def __init__(self):
+        self._notes: List[Note] = []
+        self._todos: Dict[str, Todo] = {}
+        self._file_cache: Dict[str, Dict[str, Any]] = {}
+        self._lock = RLock()
+        logger.info("SharedMemory initialized")
+
+    # --- Internal state mutation (invoked through MemoryView) -----------
+
+    def _add_note(self, note: Note) -> bool:
+        with self._lock:
+            for existing in self._notes:
+                if existing.content == note.content and existing.file_path == note.file_path:
+                    return False
+            self._notes.append(note)
+            logger.debug(f"note+ [{note.source}] {note.content}")
+            return True
+
+    def _remove_note(self, content: str) -> bool:
+        with self._lock:
+            for i, n in enumerate(self._notes):
+                if n.content == content:
+                    del self._notes[i]
+                    return True
+            return False
+
+    def _get_notes(self, *, tags: Optional[List[str]] = None,
+                   file_path: Optional[str] = None) -> List[Note]:
+        with self._lock:
+            notes = list(self._notes)
+        if tags:
+            notes = [n for n in notes if any(t in n.tags for t in tags)]
+        if file_path is not None:
+            notes = [n for n in notes if n.file_path == file_path]
+        return notes
+
+    def _add_todo(self, todo: Todo) -> str:
+        with self._lock:
+            for existing in self._todos.values():
+                if existing.content.strip() == todo.content.strip():
+                    return existing.id
+            self._todos[todo.id] = todo
+            logger.debug(f"todo+ [{todo.source}] {todo.content}")
+            return todo.id
+
+    def _update_todo(self, todo_id: str, *, status: Optional[TodoStatus] = None,
+                     owner: Optional[str] = None) -> bool:
+        with self._lock:
+            todo = self._todos.get(todo_id)
+            if not todo:
+                return False
+            if status is not None:
+                todo.status = status
+            if owner is not None:
+                todo.owner = owner
+            todo.updated_at = datetime.now().isoformat()
+            return True
+
+    def _remove_todo(self, todo_id: str) -> bool:
+        with self._lock:
+            return self._todos.pop(todo_id, None) is not None
+
+    def _get_todos(self, *, status: Optional[TodoStatus] = None,
+                   target_file: Optional[str] = None) -> List[Todo]:
+        with self._lock:
+            todos = list(self._todos.values())
+        if status is not None:
+            todos = [t for t in todos if t.status == status]
+        if target_file is not None:
+            todos = [t for t in todos if t.target_file == target_file]
+        return todos
+
+    def _cache_file(self, file_path: str, analysis: Dict[str, Any]) -> None:
+        with self._lock:
+            self._file_cache[file_path] = analysis
+
+    def _get_file_cache(self, file_path: str) -> Optional[Dict[str, Any]]:
+        with self._lock:
+            return self._file_cache.get(file_path)
+
+    def _analyzed_files(self) -> List[str]:
+        with self._lock:
+            return list(self._file_cache.keys())
+
+    # --- Session-level controls ----------------------------------------
+
+    def clear(self) -> None:
+        """Reset memory for a new analysis session."""
+        with self._lock:
+            self._notes.clear()
+            self._todos.clear()
+            self._file_cache.clear()
+            logger.info("SharedMemory cleared for new session")
+
+    def snapshot(self) -> Dict[str, Any]:
+        with self._lock:
+            return {
+                "notes": len(self._notes),
+                "todos": len(self._todos),
+                "files_analyzed": len(self._file_cache),
+            }
+
+    # --- View factory --------------------------------------------------
+
+    def view_for(self, role: str, file_scope: Optional[str] = None) -> "MemoryView":
+        return MemoryView(self, role=role, file_scope=file_scope)
+
+
+class MemoryView:
+    """Capability-scoped facade over SharedMemory."""
+
+    def __init__(self, memory: SharedMemory, role: str,
+                 file_scope: Optional[str] = None):
+        self._memory = memory
+        self._role = role
+        self._file_scope = file_scope
+
+    # -- reads (all roles) ----------------------------------------------
+
+    def notes(self, *, tags: Optional[List[str]] = None,
+              file_path: Optional[str] = None) -> List[Note]:
+        return self._memory._get_notes(tags=tags, file_path=file_path)
+
+    def todos(self, *, status: Optional[TodoStatus] = None,
+              target_file: Optional[str] = None) -> List[Todo]:
+        return self._memory._get_todos(status=status, target_file=target_file)
+
+    def file_cache(self, file_path: str) -> Optional[Dict[str, Any]]:
+        return self._memory._get_file_cache(file_path)
+
+    def analyzed_files(self) -> List[str]:
+        return self._memory._analyzed_files()
+
+    def summary(self) -> Dict[str, int]:
+        return {
+            "notes": len(self.notes()),
+            "todos_pending": len(self.todos(status="pending")),
+            "todos_in_progress": len(self.todos(status="in_progress")),
+            "todos_done": len(self.todos(status="done")),
+            "files_analyzed": len(self.analyzed_files()),
+        }
+
+    # -- append (all roles) ---------------------------------------------
+
+    def add_note(self, content: str, *, tags: Optional[List[str]] = None,
+                 file_path: Optional[str] = None) -> bool:
+        if not content or not content.strip():
+            return False
+        note = Note(
+            content=content.strip(),
+            source=self._role,
+            tags=list(tags or []),
+            file_path=file_path if file_path is not None else self._file_scope,
+        )
+        return self._memory._add_note(note)
+
+    def add_notes(self, contents: List[str], *, tags: Optional[List[str]] = None,
+                  file_path: Optional[str] = None) -> int:
+        added = 0
+        for c in contents or []:
+            if self.add_note(c, tags=tags, file_path=file_path):
+                added += 1
+        return added
+
+    def add_todo(self, content: str, *, target_file: Optional[str] = None) -> Optional[str]:
+        if not content or not content.strip():
+            return None
+        todo = Todo(
+            id=uuid.uuid4().hex[:8],
+            content=content.strip(),
+            source=self._role,
+            target_file=target_file if target_file is not None else self._file_scope,
+        )
+        return self._memory._add_todo(todo)
+
+    def add_todos(self, contents: List[str], *, target_file: Optional[str] = None) -> List[str]:
+        ids = []
+        for c in contents or []:
+            tid = self.add_todo(c, target_file=target_file)
+            if tid:
+                ids.append(tid)
+        return ids
+
+    # -- todo lifecycle (scoped) ----------------------------------------
+
+    def claim_todo(self, todo_id: str) -> bool:
+        if not self._can_touch_todo(todo_id):
+            logger.debug(f"role={self._role} denied claim of todo {todo_id}")
+            return False
+        return self._memory._update_todo(todo_id, status="in_progress", owner=self._role)
+
+    def complete_todo(self, todo_id: str) -> bool:
+        if not self._can_touch_todo(todo_id):
+            logger.debug(f"role={self._role} denied complete of todo {todo_id}")
+            return False
+        return self._memory._update_todo(todo_id, status="done", owner=self._role)
+
+    # -- file cache (scoped for file_analysis) --------------------------
+
+    def cache_file_analysis(self, file_path: str, analysis: Dict[str, Any]) -> bool:
+        if self._role == ROLE_FILE_ANALYSIS and self._file_scope is not None \
+                and file_path != self._file_scope:
+            logger.debug(
+                f"role={self._role} denied cache write for {file_path} "
+                f"(scope={self._file_scope})"
+            )
+            return False
+        self._memory._cache_file(file_path, analysis)
+        return True
+
+    # -- orchestrator-only ----------------------------------------------
+
+    def remove_note(self, content: str) -> bool:
+        if self._role != ROLE_ORCHESTRATOR:
+            return False
+        return self._memory._remove_note(content)
+
+    def remove_todo(self, todo_id: str) -> bool:
+        if self._role != ROLE_ORCHESTRATOR:
+            return False
+        return self._memory._remove_todo(todo_id)
+
+    def reset(self) -> bool:
+        if self._role != ROLE_ORCHESTRATOR:
+            return False
+        self._memory.clear()
+        return True
+
+    # -- prompt rendering -----------------------------------------------
+
+    def format_notes(self, *, limit: Optional[int] = None,
+                     file_path: Optional[str] = None) -> str:
+        notes = self.notes(file_path=file_path)
+        if limit:
+            notes = notes[-limit:]
+        if not notes:
+            return ""
+        return "\n".join(f"- {n.format()}" for n in notes)
+
+    def format_todos(self, *, status: Optional[TodoStatus] = None,
+                     target_file: Optional[str] = None) -> str:
+        todos = self.todos(status=status, target_file=target_file)
+        if not todos:
+            return ""
+        return "\n".join(f"{t.id}: {t.format()}" for t in todos)
+
+    def format_for_prompt(self, *, file_path: Optional[str] = None) -> str:
+        """Render the memory as a single block suitable for injecting into a prompt.
+
+        Only sections with content are included.
+        """
+        sections = []
+
+        notes_block = self.format_notes(file_path=file_path)
+        if notes_block:
+            sections.append(f"### Notes (codebase observations)\n{notes_block}")
+
+        pending = self.format_todos(status="pending", target_file=file_path)
+        in_progress = self.format_todos(status="in_progress", target_file=file_path)
+        if pending or in_progress:
+            todo_lines = []
+            if pending:
+                todo_lines.append(pending)
+            if in_progress:
+                todo_lines.append(in_progress)
+            sections.append(
+                "### Pending Todos (address these where relevant)\n"
+                + "\n".join(todo_lines)
+            )
+
+        analyzed = self.analyzed_files()
+        if analyzed:
+            preview = ", ".join(analyzed[:15])
+            if len(analyzed) > 15:
+                preview += f", ... (+{len(analyzed) - 15} more)"
+            sections.append(f"### Already Analyzed Files\n{preview}")
+
+        return "\n\n".join(sections)
+
+    # -- internals ------------------------------------------------------
+
+    def _can_touch_todo(self, todo_id: str) -> bool:
+        if self._role == ROLE_ORCHESTRATOR:
+            return True
+        todo = next((t for t in self.todos() if t.id == todo_id), None)
+        if todo is None:
+            return False
+        if self._role == ROLE_FILE_ANALYSIS:
+            if todo.source == self._role:
+                return True
+            if self._file_scope is not None and todo.target_file == self._file_scope:
+                return True
+        return False

--- a/src/core/shared_memory.py
+++ b/src/core/shared_memory.py
@@ -237,13 +237,20 @@ class MemoryView:
         return added
 
     def add_todo(self, content: str, *, target_file: Optional[str] = None) -> Optional[str]:
+        """Add a new todo.
+
+        ``target_file`` is intentionally NOT defaulted to ``self._file_scope``:
+        a todo created during analysis of one file is usually a check that
+        applies elsewhere (e.g. discovered in ``src/auth.py`` but actually
+        about ``test_auth.py``). The creator must opt in to scoping.
+        """
         if not content or not content.strip():
             return None
         todo = Todo(
             id=uuid.uuid4().hex[:8],
             content=content.strip(),
             source=self._role,
-            target_file=target_file if target_file is not None else self._file_scope,
+            target_file=target_file,
         )
         return self._memory._add_todo(todo)
 
@@ -319,27 +326,35 @@ class MemoryView:
         return "\n".join(f"{t.id}: {t.format()}" for t in todos)
 
     def format_for_prompt(self, *, file_path: Optional[str] = None) -> str:
-        """Render the memory as a single block suitable for injecting into a prompt.
+        """Render memory as a single block suitable for injecting into a prompt.
 
-        Only sections with content are included.
+        When ``file_path`` is provided, both items targeting that file AND
+        unscoped (global) items are included; items scoped to other files are
+        omitted to keep the prompt focused. Items relevant to the current
+        file are marked with ``(this file)`` so the agent knows to address
+        them first.
         """
+        def _is_relevant(scope: Optional[str]) -> bool:
+            if file_path is None:
+                return True
+            return scope is None or scope == file_path
+
+        def _scope_marker(scope: Optional[str]) -> str:
+            return " (this file)" if file_path is not None and scope == file_path else ""
+
         sections = []
 
-        notes_block = self.format_notes(file_path=file_path)
-        if notes_block:
-            sections.append(f"### Notes (codebase observations)\n{notes_block}")
+        relevant_notes = [n for n in self.notes() if _is_relevant(n.file_path)]
+        if relevant_notes:
+            lines = [f"- {n.format()}{_scope_marker(n.file_path)}" for n in relevant_notes]
+            sections.append("### Notes (codebase observations)\n" + "\n".join(lines))
 
-        pending = self.format_todos(status="pending", target_file=file_path)
-        in_progress = self.format_todos(status="in_progress", target_file=file_path)
-        if pending or in_progress:
-            todo_lines = []
-            if pending:
-                todo_lines.append(pending)
-            if in_progress:
-                todo_lines.append(in_progress)
+        active = [t for t in self.todos() if t.status in ("pending", "in_progress")
+                  and _is_relevant(t.target_file)]
+        if active:
+            lines = [f"{t.id}: {t.format()}{_scope_marker(t.target_file)}" for t in active]
             sections.append(
-                "### Pending Todos (address these where relevant)\n"
-                + "\n".join(todo_lines)
+                "### Pending Todos (address these where relevant)\n" + "\n".join(lines)
             )
 
         analyzed = self.analyzed_files()

--- a/src/utils/cli_status.py
+++ b/src/utils/cli_status.py
@@ -102,12 +102,40 @@ class CLIProcessingStatus:
         """Callback handler for agent events - matches the expected signature"""
         self.add_event(event_type, data)
     
+    MEMORY_ACTION_ICONS = {
+        'todo_added':      '➕',
+        'todo_claimed':    '🔄',
+        'todo_completed':  '✅',
+        'todo_reopened':   '↩️ ',
+        'todo_removed':    '🗑️ ',
+        'note_added':      '📝',
+        'note_removed':    '🗑️ ',
+        'reset':           '♻️ ',
+    }
+
+    MEMORY_ACTION_COLORS = {
+        'todo_added':      'cyan',
+        'todo_claimed':    'yellow',
+        'todo_completed':  'bright_green',
+        'todo_reopened':   'yellow',
+        'todo_removed':    'dim',
+        'note_added':      'cyan',
+        'note_removed':    'dim',
+        'reset':           'dim',
+    }
+
     def _format_event(self, event: ProcessingEvent) -> Text:
         """Format a single event for display"""
-        icon = self.EVENT_ICONS.get(event.type, '📌')
-        color = self.EVENT_COLORS.get(event.type, 'white')
-        
         text = Text()
+
+        if event.type == 'memory_update':
+            action = event.data.get('action', '')
+            icon = self.MEMORY_ACTION_ICONS.get(action, self.EVENT_ICONS['memory_update'])
+            color = self.MEMORY_ACTION_COLORS.get(action, self.EVENT_COLORS['memory_update'])
+        else:
+            icon = self.EVENT_ICONS.get(event.type, '📌')
+            color = self.EVENT_COLORS.get(event.type, 'white')
+
         text.append(f" {icon} ", style=color)
         
         # Format based on event type
@@ -145,12 +173,7 @@ class CLIProcessingStatus:
                 text.append("...", style="dim")
         
         elif event.type == 'memory_update':
-            action = event.data.get('action', 'Updated')
-            message = event.data.get('message', '')[:50]
-            text.append(f"{action}: ", style=f"bold {color}")
-            text.append(message, style="italic")
-            if len(event.data.get('message', '')) > 50:
-                text.append("...", style="dim")
+            self._format_memory_update(event, text)
         
         elif event.type == 'search':
             query = event.data.get('query', '')[:40]
@@ -180,9 +203,78 @@ class CLIProcessingStatus:
         # Add timestamp
         time_str = event.timestamp.strftime("%H:%M:%S")
         text.append(f"  [{time_str}]", style="dim")
-        
+
         return text
-    
+
+    def _format_memory_update(self, event: ProcessingEvent, text: Text) -> None:
+        """Render a memory_update event.
+
+        Todo lifecycle events render as a checkbox-style line so the user can
+        visually track add/claim/complete transitions. Note changes and resets
+        render as "Memory Updated: <action>" so the user sees the orchestrator
+        growing or pruning its memory.
+        """
+        data = event.data
+        action = data.get('action', '')
+        role = data.get('role', '')
+        content = data.get('content', '')
+        target = data.get('target_file')
+        color = self.MEMORY_ACTION_COLORS.get(action, self.EVENT_COLORS['memory_update'])
+
+        role_tag = f"[{role}] " if role else ""
+
+        if action == 'todo_added':
+            text.append("Todo added ", style=f"bold {color}")
+            text.append(role_tag, style="dim")
+            text.append(f"[ ] {content}", style=color)
+            if target:
+                text.append(f"  → {target}", style="dim")
+
+        elif action == 'todo_claimed':
+            text.append("Todo in progress ", style=f"bold {color}")
+            text.append(role_tag, style="dim")
+            text.append(f"[~] {content}", style=color)
+
+        elif action == 'todo_completed':
+            text.append("Todo completed ", style=f"bold {color}")
+            text.append(role_tag, style="dim")
+            text.append(f"[x] {content}", style=f"{color} strike")
+
+        elif action == 'todo_reopened':
+            text.append("Todo reopened ", style=f"bold {color}")
+            text.append(role_tag, style="dim")
+            text.append(f"[ ] {content}", style=color)
+
+        elif action == 'todo_removed':
+            text.append("Memory updated: ", style=f"bold {color}")
+            text.append(role_tag, style="dim")
+            text.append(f"todo removed - {content}", style=f"{color} strike")
+
+        elif action == 'note_added':
+            text.append("Memory updated: ", style=f"bold {color}")
+            text.append(role_tag, style="dim")
+            text.append(f"note added - {content}", style=f"italic {color}")
+
+        elif action == 'note_removed':
+            text.append("Memory updated: ", style=f"bold {color}")
+            text.append(role_tag, style="dim")
+            text.append(f"note removed - {content}", style=f"italic {color}")
+
+        elif action == 'reset':
+            notes_cleared = data.get('notes_cleared', 0)
+            todos_cleared = data.get('todos_cleared', 0)
+            files_cleared = data.get('files_cleared', 0)
+            text.append("Memory updated: ", style=f"bold {color}")
+            text.append(
+                f"reset ({notes_cleared} notes, {todos_cleared} todos, "
+                f"{files_cleared} file entries cleared)",
+                style=f"italic {color}",
+            )
+
+        else:
+            text.append("Memory updated: ", style=f"bold {color}")
+            text.append(f"{action} {content}", style=color)
+
     def _build_display(self) -> Panel:
         """Build the rich display panel"""
         visible_events = self.events[-self.max_visible_events:]
@@ -280,6 +372,8 @@ class SimpleProcessingStatus:
     
     EVENT_ICONS = CLIProcessingStatus.EVENT_ICONS
     EVENT_COLORS = CLIProcessingStatus.EVENT_COLORS
+    MEMORY_ACTION_ICONS = CLIProcessingStatus.MEMORY_ACTION_ICONS
+    MEMORY_ACTION_COLORS = CLIProcessingStatus.MEMORY_ACTION_COLORS
     
     def __init__(self, console: Optional[Console] = None):
         self.console = console or Console()
@@ -290,15 +384,24 @@ class SimpleProcessingStatus:
     def add_event(self, event_type: str, data: dict):
         """Add and immediately print a new processing event"""
         self.event_count += 1
+
+        if event_type == 'memory_update':
+            action = data.get('action', '')
+            icon = self.MEMORY_ACTION_ICONS.get(action, self.EVENT_ICONS['memory_update'])
+            color = self.MEMORY_ACTION_COLORS.get(action, self.EVENT_COLORS['memory_update'])
+            msg = self._memory_update_message(data)
+            self.console.print(f"  [{color}]{icon}[/{color}] {msg}")
+            return
+
         icon = self.EVENT_ICONS.get(event_type, '📌')
         color = self.EVENT_COLORS.get(event_type, 'white')
-        
+
         # Update tracking
         if event_type == 'iteration':
             self.current_iteration = data.get('current', self.current_iteration)
         elif event_type == 'file_analysis':
             self.files_analyzed += 1
-        
+
         # Format message
         if event_type == 'file_analysis':
             file_path = data.get('file_path', 'unknown')
@@ -314,16 +417,43 @@ class SimpleProcessingStatus:
             msg = f"Iteration {current}/{max_iter} ({files} files analyzed)"
         elif event_type == 'reasoning':
             msg = data.get('message', '')[:80]
-        elif event_type == 'memory_update':
-            action = data.get('action', 'Updated')
-            message = data.get('message', '')[:50]
-            msg = f"{action}: {message}"
         elif event_type == 'thinking':
             msg = data.get('message', 'Processing...')
         else:
             msg = data.get('message', str(data))[:60]
-        
+
         self.console.print(f"  [{color}]{icon}[/{color}] {msg}")
+
+    @staticmethod
+    def _memory_update_message(data: dict) -> str:
+        action = data.get('action', '')
+        role = data.get('role', '')
+        content = data.get('content', '')
+        target = data.get('target_file')
+        role_tag = f"[{role}] " if role else ""
+        if action == 'todo_added':
+            suffix = f"  → {target}" if target else ""
+            return f"Todo added {role_tag}[ ] {content}{suffix}"
+        if action == 'todo_claimed':
+            return f"Todo in progress {role_tag}[~] {content}"
+        if action == 'todo_completed':
+            return f"Todo completed {role_tag}[x] {content}"
+        if action == 'todo_reopened':
+            return f"Todo reopened {role_tag}[ ] {content}"
+        if action == 'todo_removed':
+            return f"Memory updated: {role_tag}todo removed - {content}"
+        if action == 'note_added':
+            return f"Memory updated: {role_tag}note added - {content}"
+        if action == 'note_removed':
+            return f"Memory updated: {role_tag}note removed - {content}"
+        if action == 'reset':
+            return (
+                f"Memory updated: reset "
+                f"({data.get('notes_cleared', 0)} notes, "
+                f"{data.get('todos_cleared', 0)} todos, "
+                f"{data.get('files_cleared', 0)} file entries cleared)"
+            )
+        return f"Memory updated: {action} {content}".strip()
     
     def on_event(self, event_type: str, data: dict):
         """Callback handler for agent events"""


### PR DESCRIPTION
## Summary

Reworks the agent shared memory model on the lines of how Claude Code handles memory: durable notes (CLAUDE.md-like) + todos with status (TodoWrite-like), plus a per-file analysis cache. Access goes through a `MemoryView` facade that enforces what each agent can read and write.

## Motivation

The old `SharedMemory` was a flat list of strings with no typing, no status lifecycle, and weakly enforced permissions (a comment said "sub-agents can only append" but nothing actually stopped them from clearing the list). It conflated observations with action items and offered no way to prevent one file's analysis from trampling another's cache.

## The new model

Three layers, all held by a single authoritative `SharedMemory` store:

1. **Notes** — durable observations about the codebase. Examples: "`authenticate()` at `src/auth.py:45` is the single login entry point", "payment flow uses Stripe". Think CLAUDE.md entries.
2. **Todos** — action items with explicit state (`pending` → `in_progress` → `done`), an owner, and an optional target file. Think TodoWrite list.
3. **File cache** — analysis results keyed by file path. Prevents re-analyzing the same file and lets agents look up what another agent found.

Agents never touch the store directly. They call `SharedMemory.view_for(role, file_scope)` and get a `MemoryView` that enforces capabilities:

| Capability | Orchestrator | File-analysis agent |
|---|---|---|
| Read notes / todos / cache | ✓ | ✓ |
| Append notes / todos | ✓ | ✓ |
| Claim / complete any todo | ✓ | only own todos or todos targeting its scoped file |
| Cache any file | ✓ | only its scoped file |
| Remove notes / todos | ✓ | ✗ |
| Reset memory | ✓ | ✗ |

## How agents use it

- `OrchestratorAgent` builds an orchestrator-scoped view in `__init__` (`self.memory`) and renders the full memory into analysis and chat prompts via `format_for_prompt()`.
- `FileAnalysisAgent` derives a fresh file-scoped view per `analyze_file` call via `_resolve_memory_view()`. It only sees todos targeting its file (plus unscoped ones) and can only cache the file it's analyzing.
- Agent response schemas now expose two fields: `memory_items` (todos) and a new `notes` (observations). After analysis the agent persists both through its scoped view and updates the file cache.

## Files touched

- `src/core/shared_memory.py` — rewritten. `Note`, `Todo` dataclasses; `SharedMemory` store with `_`-prefixed internal mutators; `MemoryView` facade with role-based capability checks; `format_for_prompt()` renders notes + pending/in-progress todos + analyzed-files list.
- `src/agents/schemas.py` — adds `notes` to `AnalysisResponseSchema`, `ChatResponseSchema`, `FileAnalysisResultEnhanced`.
- `src/agents/orchestrator_agent.py` — holds an orchestrator `MemoryView`, prompts updated to explain the two-layer memory model.
- `src/agents/file_analysis_agent.py` — derives file-scoped views per call; persists issues/notes/todos and caches the file analysis through the view.
- `src/core/orchestrator_engine.py` — hands out file-scoped views in `repository_context` for each file-level handler.

## Test plan

- [x] `python -m py_compile` on all modified files
- [x] Capability smoke test: orchestrator prunes notes ✓, file-analysis denied ✓; file-analysis can claim todos targeting its scope but not others ✓; file-analysis cache write denied for other files ✓; prompt rendering produces correct scoped view for each role
- [ ] Run an end-to-end `codet analyze` against a sample repo
- [ ] Run `codet chat` and confirm notes/todos accumulate sensibly across turns

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core cross-agent coordination mechanism and changes the shape/permissions of shared memory; incorrect scoping or prompt rendering could cause lost context, unresolvable todos, or stale/incorrect cache behavior across sessions.
> 
> **Overview**
> Reworks shared agent memory from a flat string list into a structured `SharedMemory` store with **durable `notes`**, **statusful `todos`** (`pending`/`in_progress`/`done`), and a **per-file analysis cache**, all accessed via a role- and file-scoped `MemoryView` that enforces what each agent can mutate.
> 
> Updates the orchestrator and file-analysis agents (and `OrchestratorEngine`) to pass the appropriate scoped view via `repository_context`, render memory into prompts using `format_for_prompt()`, and persist new `memory_items` as todos plus new `notes` from model responses; response schemas are extended to include the new `notes` field alongside `memory_items`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d14a8e18726478c92109bdbecf0061c7adbddd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->